### PR TITLE
Refactor flashlist body

### DIFF
--- a/flashlist_flutter/lib/src/features/flashlist/application/flashlist_stream_message_handler.dart
+++ b/flashlist_flutter/lib/src/features/flashlist/application/flashlist_stream_message_handler.dart
@@ -125,13 +125,17 @@ void handleFlashlistStreamMessage(
     final flashListToUpdate =
         getFlashlistByFromStream(streamItems, message.parentId);
 
-    final itemToUpdate = flashListToUpdate!.items!
-        .firstWhere((currentItem) => currentItem!.id == message.id);
+    final itemToUpdate = flashListToUpdate!.items!.firstWhere(
+      (currentItem) => currentItem!.id == message.id,
+      orElse: () => null,
+    );
 
-    flashListToUpdate.items!
-        .removeWhere((currentItem) => currentItem!.id == message.id);
+    if (itemToUpdate != null) {
+      flashListToUpdate.items!
+          .removeWhere((currentItem) => currentItem!.id == message.id);
 
-    updateOrderNrForSiblings(flashListToUpdate.items!, itemToUpdate!, null);
+      updateOrderNrForSiblings(flashListToUpdate.items!, itemToUpdate, null);
+    }
   }
 
   /// [ReOrderFlashlistItem] is a message that contains the [id] of a [FlashlistItem]

--- a/flashlist_flutter/lib/src/features/flashlist/presentation/flashlist_items/mixins/flashlist_item_deletion_handler.dart
+++ b/flashlist_flutter/lib/src/features/flashlist/presentation/flashlist_items/mixins/flashlist_item_deletion_handler.dart
@@ -1,0 +1,78 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import 'package:flashlist_client/flashlist_client.dart';
+import 'package:flashlist_flutter/src/features/flashlist/presentation/flashlist_items/flashlist_body.dart';
+import 'package:flashlist_flutter/src/utils/context_helper.dart';
+
+/// A mixin handling the deletion of a FlashlistItem
+/// Provides [handleDebouncedDeletion] to handle the deletion of a FlashlistItem
+/// Shows a SnackBar with an undo action for 5 seconds
+/// If the action is not undone, the item is deleted
+mixin FlashlistItemDeletionHandler on ConsumerState<FlashlistBody> {
+  Completer<void>? completer;
+  late Timer timer;
+  late FlashlistItem pendingItem;
+  int? pendingItemIndex;
+
+  /// Gets the FlashlistItems from the consuming class
+  List<FlashlistItem?> getFlashlistItems();
+
+  /// Deletes the FlashlistItem on the remote from the consuming class
+  void deleteItemOnRemote(int itemId, int parentId);
+
+  /// Handles the deletion of a FlashlistItem by removing it from the FlashlistBody
+  /// and showing a SnackBar with an undo action for 3 seconds
+  /// If the action is not undone, the item is [deleteItemOnRemote]
+  void handleDebouncedDeletion(
+    BuildContext context,
+    FlashlistItem item,
+  ) {
+    List<FlashlistItem?> flashlistItems = getFlashlistItems();
+
+    // If there is a pending item, delete it and cancel the timer
+    if (completer != null && !completer!.isCompleted) {
+      timer.cancel();
+      deleteItemOnRemote(item.id!, item.parentId);
+    }
+
+    completer = Completer<void>();
+    pendingItem = item;
+    pendingItemIndex = flashlistItems.indexOf(item);
+
+    setState(() {
+      flashlistItems.remove(item);
+    });
+
+    timer = Timer(const Duration(seconds: 3), () {
+      if (!completer!.isCompleted) {
+        deleteItemOnRemote(item.id!, item.parentId);
+        completer!.complete();
+      }
+    });
+
+    context.showContextSnackBar(
+      context,
+      message: 'Item deleted',
+      duration: const Duration(seconds: 3),
+      action: SnackBarAction(
+        label: 'Undo',
+        onPressed: () {
+          if (!completer!.isCompleted) {
+            setState(() {
+              if (flashlistItems.length < item.orderNr) {
+                flashlistItems.add(item);
+              } else {
+                flashlistItems.insert(pendingItemIndex!, item);
+              }
+            });
+            completer!.complete();
+            timer.cancel();
+          }
+        },
+      ),
+    );
+  }
+}

--- a/flashlist_flutter/lib/src/features/flashlist/presentation/flashlist_items/mixins/flashlist_item_reorder_handler.dart
+++ b/flashlist_flutter/lib/src/features/flashlist/presentation/flashlist_items/mixins/flashlist_item_reorder_handler.dart
@@ -1,0 +1,88 @@
+import 'dart:ui';
+
+import 'package:flashlist_flutter/src/features/flashlist/presentation/flashlist_items/flashlist_item.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import 'package:flashlist_client/flashlist_client.dart';
+import 'package:flashlist_flutter/src/features/flashlist/application/flashlist_controller.dart';
+import 'package:flashlist_flutter/src/features/flashlist/presentation/flashlist_items/flashlist_body.dart';
+
+/// A mixin handling the reordering of FlashlistItems
+/// Provides [handleFlashlistItemReorder] to handle the reordering of FlashlistItems
+/// Provides [buildReorderableItems] to build a list of ReorderableDelayedDragStartListener
+/// Provides [buildProxyDecorator] to build a proxy decorator for the ReorderableListView
+/// Expects [getFlashlistItems] to be implemented by the consuming class
+mixin FlashlistItemReorderHandler on ConsumerState<FlashlistBody> {
+  List<FlashlistItem?> getFlashlistItems();
+
+  /// Takes a list of FlashlistItems and a function to handle the deletion of a FlashlistItem
+  /// And Wraps the FlashlistItems in ReorderableDelayedDragStartListener
+  List<ReorderableDelayedDragStartListener> buildReorderableItems(
+    List<FlashlistItem?> flashlistItems,
+    Function(BuildContext, FlashlistItem) handleFlashlistItemDeletion,
+  ) {
+    return [
+      for (final item in flashlistItems)
+        ReorderableDelayedDragStartListener(
+          index: flashlistItems.indexOf(item),
+          key: Key('reorderable-${item!.id.toString()}'),
+          child: FlashlistItemWidget(
+            item: item,
+            onDismissed: (direction) {
+              handleFlashlistItemDeletion(context, item);
+            },
+          ),
+        ),
+    ];
+  }
+
+  /// Builds a proxy decorator around the FlashlistItem that is being reordered/grabbed
+  Widget buildProxyDecorator(
+      Widget child,
+      int index,
+      Animation<double> animation,
+      List<ReorderableDelayedDragStartListener> bodyItems) {
+    return AnimatedBuilder(
+      animation: animation,
+      builder: (BuildContext context, Widget? child) {
+        final double animValue = Curves.easeInOut.transform(animation.value);
+        final double elevation = lerpDouble(1, 6, animValue)!;
+        final double scale = lerpDouble(1, 1.02, animValue)!;
+        return Transform.scale(
+          scale: scale,
+          child: Card(
+            shape: const ContinuousRectangleBorder(),
+            elevation: elevation,
+            child: bodyItems[index].child,
+          ),
+        );
+      },
+      child: child,
+    );
+  }
+
+  /// Handles the reordering of FlashlistItems
+  void handleFlashlistItemReorder(int oldIndex, int newIndex) {
+    final flashlistItems = getFlashlistItems();
+    if (oldIndex < newIndex) {
+      newIndex -= 1;
+    }
+    final item = flashlistItems.removeAt(oldIndex);
+    flashlistItems.insert(newIndex, item);
+
+    int newOrderNr = newIndex + 1;
+    if (newOrderNr > flashlistItems.length) {
+      newOrderNr = flashlistItems.length;
+    }
+
+    ref.read(flashlistControllerProvider).reOrderFlashlistItems(
+          ReOrderFlashlistItem(
+            id: item!.id!,
+            parentId: widget.flashlist.id!,
+            oldOrderNr: oldIndex + 1,
+            newOrderNr: newOrderNr,
+          ),
+        );
+  }
+}

--- a/flashlist_flutter/lib/src/utils/context_helper.dart
+++ b/flashlist_flutter/lib/src/utils/context_helper.dart
@@ -26,14 +26,12 @@ MediaQueryData mediaQueryOf(context) {
 }
 
 extension ShowSnackBar on BuildContext {
-  void showContextSnackBar(
-    context, {
-    required String message,
-    SnackBarAction? action,
-  }) {
+  void showContextSnackBar(context,
+      {required String message, SnackBarAction? action, Duration? duration}) {
     ScaffoldMessenger.of(context).clearSnackBars();
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
+        duration: duration ?? const Duration(seconds: 5),
         action: action,
         backgroundColor: colorSchemeOf(context).primary,
         content: Text(message),


### PR DESCRIPTION
FlashlistBody is now slimmer and implements two custom mixins:
- FlashlistItemDeletionHandler - Adds a delay between the a FlashlistItem being dismissed and it being deleted on remote, to give the user the option to "undo" the deletion.
- FlashlistItemReorderHandler - Holds most of the logic necessary to build ReorderableDelayedDragStartListener around the list and handle reordering locally and on remote