### PR TITLE
Small fixes

### DIFF
--- a/flashlist_flutter/lib/src/features/flashlist/presentation/share/share_with_connections.dart
+++ b/flashlist_flutter/lib/src/features/flashlist/presentation/share/share_with_connections.dart
@@ -55,37 +55,46 @@ class ShareWithConnections extends ConsumerWidget {
           shrinkWrap: true,
           itemCount: connections.length,
           itemBuilder: (context, index) {
-            // TODO: think about just disabling the connection if it's already an author
             final connection = connections[index];
-            final authorIds =
-                Set.from(flashlist.authors!.map((c) => c?.userId));
-            if (authorIds.contains(connection?.userId)) {
-              return const SizedBox.shrink();
+
+            if (connection == null) {
+              return const SizedBox();
             }
 
-            return ListTile(
-              leading: AvatarPlaceholder(
-                radius: Sizes.p20,
-                username: connection!.username,
-              ),
-              title: Text(connection.username),
-              onTap: () async {
-                final wantsToShare = await showConfirmDialog(
-                  context: context,
-                  title: context.localizations
-                      .inviteNamedUser(connection.username),
-                  content: context.localizations.wantToInviteNamedUserMessage(
-                    connection.username,
-                    flashlist.title,
-                  ),
-                  confirmAction: context.localizations.share,
-                  cancelAction: context.localizations.cancel,
-                );
+            final authorIds =
+                Set.from(flashlist.authors?.map((c) => c?.userId) ?? []);
 
-                if (wantsToShare == true) {
-                  shareWithConnection(connection);
-                }
-              },
+            final isAuthor = authorIds.contains(connection.userId);
+
+            return Opacity(
+              opacity: isAuthor ? 0.3 : 1.0,
+              child: ListTile(
+                leading: AvatarPlaceholder(
+                  radius: Sizes.p20,
+                  username: connection.username,
+                ),
+                title: Text(connection.username),
+                onTap: isAuthor
+                    ? null
+                    : () async {
+                        final wantsToShare = await showConfirmDialog(
+                          context: context,
+                          title: context.localizations
+                              .inviteNamedUser(connection.username),
+                          content: context.localizations
+                              .wantToInviteNamedUserMessage(
+                            connection.username,
+                            flashlist.title,
+                          ),
+                          confirmAction: context.localizations.share,
+                          cancelAction: context.localizations.cancel,
+                        );
+
+                        if (wantsToShare == true) {
+                          shareWithConnection(connection);
+                        }
+                      },
+              ),
             );
           },
         );

--- a/flashlist_server/lib/src/helpers/user/user_helper.dart
+++ b/flashlist_server/lib/src/helpers/user/user_helper.dart
@@ -14,7 +14,7 @@ class UserHelper {
     try {
       final userId = await getAuthenticatedUserId(session);
       if (userId == null) {
-        throw Exception('User not authenticated');
+        return null;
       }
 
       final user = await AppUser.db.findFirstRow(


### PR DESCRIPTION
This fixes
-  An Error that happened when a newly created list was taken to the share dialog / when flashlist.authors == null 
- In the share dialog: If a user is already editor he is not hidden but the tap-event is disabled
- When no user was logged in an exception was thrown. This was removed too.

